### PR TITLE
Shorten calculation of "hour"

### DIFF
--- a/clock/js/experiment.js
+++ b/clock/js/experiment.js
@@ -24,13 +24,7 @@ $(function(){
     function startClock() {
         var angle = 360/60,
             date = new Date(),
-            hour = (function() {
-                var h = date.getHours();
-                if(h > 12) {
-                    h = h - 12;
-                }
-                return h
-            })(),
+            hour = date.getHours() % 12,
             minute = date.getMinutes(),
             second = date.getSeconds(),
             hourAngle = (360/12) * hour + (360/(12*60)) * minute;


### PR DESCRIPTION
It's not exactly equivalent as your code could output an hour of 12 while mine strictly limits it from 0 to 11. Should be fine though.
